### PR TITLE
Handling Null/Undefined Values in Properties

### DIFF
--- a/asset-properties-widget/common/asset-property-constant.ts
+++ b/asset-properties-widget/common/asset-property-constant.ts
@@ -214,6 +214,7 @@ export const devicePropertiesBaseObject = [
     label: 'Active alarms status',
     type: 'object',
     isEditable: false,
+    isExistingProperty: true,
     name: 'c8y_ActiveAlarmsStatus',
     c8y_JsonSchema: {
       properties: {
@@ -247,6 +248,7 @@ export const devicePropertiesBaseObject = [
     label: 'Address',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_Address',
     c8y_JsonSchema: {
       properties: {
@@ -288,6 +290,7 @@ export const devicePropertiesBaseObject = [
     label: 'Agent',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_Agent',
     c8y_JsonSchema: {
       properties: {
@@ -321,6 +324,7 @@ export const devicePropertiesBaseObject = [
     label: 'Availability',
     type: 'object',
     isEditable: false,
+    isExistingProperty: true,
     name: 'c8y_Availability',
     c8y_JsonSchema: {
       properties: {
@@ -347,6 +351,7 @@ export const devicePropertiesBaseObject = [
     label: 'Connection',
     type: 'object',
     isEditable: false,
+    isExistingProperty: true,
     name: 'c8y_Connection',
     c8y_JsonSchema: {
       properties: {
@@ -368,6 +373,7 @@ export const devicePropertiesBaseObject = [
     label: 'Communication mode',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_CommunicationMode',
     c8y_JsonSchema: {
       properties: {
@@ -389,6 +395,7 @@ export const devicePropertiesBaseObject = [
     label: 'Firmware',
     type: 'object',
     isEditable: false,
+    isExistingProperty: true,
     name: 'c8y_Firmware',
     c8y_JsonSchema: {
       properties: {
@@ -422,6 +429,7 @@ export const devicePropertiesBaseObject = [
     label: 'Hardware',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_Hardware',
     c8y_JsonSchema: {
       properties: {
@@ -451,6 +459,7 @@ export const devicePropertiesBaseObject = [
     label: 'LPWAN device',
     type: 'object',
     isEditable: false,
+    isExistingProperty: true,
     name: 'c8y_LpwanDevice',
     c8y_JsonSchema: {
       properties: {
@@ -472,6 +481,7 @@ export const devicePropertiesBaseObject = [
     label: 'Mobile',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_Mobile',
     c8y_JsonSchema: {
       properties: {
@@ -563,6 +573,11 @@ export const devicePropertiesBaseObject = [
     }
   },
   {
+    name: 'c8y_Notes',
+    label: 'Notes',
+    type: 'string',
+    isEditable: true,
+    isExistingProperty: true,
     c8y_JsonSchema: {
       properties: {
         c8y_Notes: {
@@ -573,16 +588,13 @@ export const devicePropertiesBaseObject = [
           }
         }
       }
-    },
-    name: 'c8y_Notes',
-    label: 'Notes',
-    type: 'string',
-    isEditable: true
+    }
   },
   {
     label: 'Position',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_Position',
     c8y_JsonSchema: {
       properties: {
@@ -612,6 +624,7 @@ export const devicePropertiesBaseObject = [
     label: 'Required availability',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_RequiredAvailability',
     c8y_JsonSchema: {
       properties: {
@@ -637,6 +650,7 @@ export const devicePropertiesBaseObject = [
     label: 'Software',
     type: 'object',
     isEditable: false,
+    isExistingProperty: true,
     name: 'c8y_Software',
     c8y_JsonSchema: {
       properties: {
@@ -666,6 +680,7 @@ export const devicePropertiesBaseObject = [
     label: 'Network',
     type: 'object',
     isEditable: true,
+    isExistingProperty: true,
     name: 'c8y_Network',
     c8y_JsonSchema: {
       properties: {

--- a/asset-properties-widget/component/asset-properties-view/asset-properties-view.component.html
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties-view.component.html
@@ -7,7 +7,7 @@
   class="d-contents"
 ></c8y-asset-properties>
 <div *ngIf="isEmptyWidget" style="text-align: center">
-  {{ "No Data" | translate }}
+  {{ 'No data' | translate }}
 </div>
 <div class="text-center" *ngIf="!isEmptyWidget && isLoading">
   <c8y-loading></c8y-loading>

--- a/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties-item.component.html
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties-item.component.html
@@ -1,6 +1,7 @@
+<!-- eslint-disable @angular-eslint/template/eqeqeq -->
 <ng-container [ngSwitch]="type" *ngIf="!isEdit">
   <ng-container *ngSwitchCase="'date'">
-    {{ (value | c8yDate : "fullDate") || ("Undefined" | translate) }}
+    {{ (value | c8yDate : 'fullDate') || (defaultEmptyValue | translate) }}
   </ng-container>
   <ng-container *ngSwitchCase="'file'">
     <ng-container *ngIf="file">
@@ -23,21 +24,19 @@
       </button>
     </ng-container>
     <ng-container *ngIf="!file">
-      {{ "No file attached." | translate }}
+      {{ 'No file attached.' | translate }}
     </ng-container>
   </ng-container>
   <ng-container *ngSwitchCase="'object'">
     <ul *ngFor="let prop of complex">
       <span *ngIf="prop.complex">
-        <label
-          class="m-b-0 m-r-8 text-truncate"
-          title="{{ prop.label | translate }}"
-        >
+        <label class="m-b-0 m-r-8 text-truncate" title="{{ prop.label | translate }}">
           {{ prop.label | translate }}
         </label>
         <c8y-asset-properties-item
           [type]="prop.type"
           [complex]="prop.complex"
+          [isExistingProperty]="prop.isExistingProperty"
         ></c8y-asset-properties-item>
       </span>
     </ul>
@@ -58,43 +57,28 @@
           >
             {{ prop.label | translate }}
           </label>
-          <span
-            class="m-l-auto"
-            style="max-width: {{ prop.file ? '50%' : '100%' }}; min-width:0;"
-          >
+          <span class="m-l-auto" style="max-width: {{ prop.file ? '50%' : '100%' }}; min-width:0;">
             <c8y-asset-properties-item
               [file]="prop.file"
               [key]="prop.key"
               [type]="prop.type"
               [value]="prop.value"
+              [isExistingProperty]="prop.isExistingProperty"
             ></c8y-asset-properties-item>
           </span>
         </li>
       </span>
     </ul>
   </ng-container>
-  <ng-container
-    *ngSwitchCase="type === 'number' || type === 'boolean' ? type : ''"
-  >
-    <p
-      class="text-truncate"
-      title="{{ value !== null ? value : ('Undefined' | translate) }}"
-    >
-      {{ value !== null ? value : ("Undefined" | translate) }}
+  <ng-container *ngSwitchCase="type === 'number' || type === 'boolean' ? type : ''">
+    <p class="text-truncate" title="{{ value !== null ? value : (defaultEmptyValue | translate) }}">
+      {{ value != null ? value : (defaultEmptyValue | translate) }}
     </p>
   </ng-container>
   <ng-container *ngSwitchDefault>
-    <p
-      class="text-truncate"
-      title="{{ (value | translate) || ('Undefined' | translate) }}"
-    >
-      {{ (value | translate) || ("Undefined" | translate) }}
+    <p class="text-truncate" title="{{ (value | translate) || (defaultEmptyValue | translate) }}">
+      {{ (value | translate) || (defaultEmptyValue | translate) }}
     </p>
   </ng-container>
 </ng-container>
-<formly-form
-  *ngIf="isEdit"
-  [form]="form"
-  [fields]="fields"
-  [model]="model"
-></formly-form>
+<formly-form *ngIf="isEdit" [form]="form" [fields]="fields" [model]="model"></formly-form>

--- a/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties-item.component.ts
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties-item.component.ts
@@ -1,12 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { FormControl, FormGroup, ValidationErrors } from '@angular/forms';
 import { IManagedObjectBinary } from '@c8y/client';
-import {
-  AlertService,
-  C8yJSONSchema,
-  gettext,
-  FilesService,
-} from '@c8y/ngx-components';
+import { AlertService, C8yJSONSchema, gettext, FilesService } from '@c8y/ngx-components';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { AssetPropertiesItem } from './asset-properties.model';
 import { JSONSchema7 } from 'json-schema';
@@ -19,7 +14,7 @@ export class MaxLengthValidator {
         return null;
       }
       if (control.value.length > maxLength) {
-         control.setValue(control.value.substring(0, maxLength));
+        control.setValue(control.value.substring(0, maxLength));
       }
       return null;
     };
@@ -28,11 +23,9 @@ export class MaxLengthValidator {
 
 @Component({
   selector: 'c8y-asset-properties-item',
-  templateUrl: './asset-properties-item.component.html',
+  templateUrl: './asset-properties-item.component.html'
 })
-export class AssetPropertiesItemComponent
-  implements AssetPropertiesItem, OnChanges
-{
+export class AssetPropertiesItemComponent implements AssetPropertiesItem, OnChanges {
   @Input()
   key: string;
   @Input()
@@ -55,11 +48,14 @@ export class AssetPropertiesItemComponent
   isEditable: boolean;
   @Input()
   active: boolean;
+  @Input()
+  isExistingProperty: boolean;
 
   form: FormGroup;
   fields: FormlyFieldConfig[];
   model: any;
   previewImage: string;
+  defaultEmptyValue: string;
 
   constructor(
     private alert: AlertService,
@@ -72,6 +68,7 @@ export class AssetPropertiesItemComponent
       this.resolveJsonSchema();
       await this.resolveFile();
     }
+    this.defaultEmptyValue = this.isExistingProperty ? 'No data' : 'Undefined';
   }
 
   private async resolveFile() {
@@ -114,8 +111,10 @@ export class AssetPropertiesItemComponent
       const fieldConfig = this.c8yJsonSchemaService.toFieldConfig(this.jsonSchema as JSONSchema7, {
         map(mappedField: FormlyFieldConfig) {
           const result: FormlyFieldConfig = mappedField;
-          if(mappedField.key === 'name'){
-            mappedField.validators = {...{validation: [MaxLengthValidator.maxLength(assetNameMaxLength)]}};
+          if (mappedField.key === 'name') {
+            mappedField.validators = {
+              ...{ validation: [MaxLengthValidator.maxLength(assetNameMaxLength)] }
+            };
           }
           return result;
         }

--- a/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties.component.html
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties.component.html
@@ -43,6 +43,7 @@
             [complex]="prop.complex"
             [isEdit]="prop.isEdit"
             [jsonSchema]="prop.jsonSchema"
+            [isExistingProperty]="prop.isExistingProperty"
           ></c8y-asset-properties-item>
           <div
             *ngIf="
@@ -66,7 +67,7 @@
             type="button"
             (click)="toggleEdit(prop)"
           >
-            {{ "Cancel" | translate }}
+            {{ 'Cancel' | translate }}
           </button>
           <button
             class="btn btn-primary btn-sm"
@@ -76,7 +77,7 @@
             [disabled]="!assetProps?.form?.valid"
             (click)="save(assetProps.form.value, prop)"
           >
-            {{ "Save" | translate }}
+            {{ 'Save' | translate }}
           </button>
         </div>
       </div>

--- a/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties.component.ts
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties.component.ts
@@ -154,7 +154,8 @@ export class AssetPropertiesComponent implements OnChanges, OnInit {
           jsonSchema: mo.c8y_JsonSchema,
           lastUpdated: mo.lastUpdated,
           isEditable: mo.isEditable,
-          active: properties[key].active as boolean
+          active: properties[key].active as boolean,
+          isExistingProperty: mo.isExistingProperty
         });
       }
     }
@@ -271,7 +272,7 @@ export class AssetPropertiesComponent implements OnChanges, OnInit {
         value =
           asset.c8y_Availability?.lastMessage ??
           this.computedPropertyObject?.[mo.name] ??
-          'Undefined';
+          'No data';
         break;
       case 'lastMeasurement':
         value = this.computedPropertyObject
@@ -279,7 +280,7 @@ export class AssetPropertiesComponent implements OnChanges, OnInit {
               this.computedPropertyObject[`${mo.name}_${mo.config.id}`],
               mo.config.resultTypes
             )
-          : 'Undefined';
+          : 'No data';
         break;
       case 'childDevicesCount':
         value = asset.childDevices.references.length;
@@ -288,10 +289,10 @@ export class AssetPropertiesComponent implements OnChanges, OnInit {
         value = asset.childAssets.references.length;
         break;
       case 'configurationSnapshot':
-        value = this.computedPropertyObject?.[mo.name] ?? 'Undefined';
+        value = this.computedPropertyObject?.[mo.name] ?? 'No data';
         break;
       default:
-        value = 'Undefined';
+        value = 'No data';
         break;
     }
     return value;

--- a/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties.model.ts
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties/asset-properties.model.ts
@@ -14,4 +14,5 @@ export interface AssetPropertiesItem {
   lastUpdated: string;
   isEditable: boolean;
   active: boolean;
+  isExistingProperty: boolean;
 }


### PR DESCRIPTION
UI Behavior has been updated:- Complex/simple custom properties will display "undefined" for keys with no value, while default properties will display "No data" for keys without values.

I fixed the issue by adding an 'isExistingProperty' flag in the constant file to differentiate between custom properties and default existing properties.