### PR TITLE
fix(asset-property-widget): correct time format handling [CTM-1293]

### DIFF
--- a/asset-properties-widget/component/asset-properties-view/asset-properties-view.component.ts
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties-view.component.ts
@@ -30,7 +30,7 @@ export class AssetPropertiesViewComponent implements OnInit {
   @Input() config: any;
   computedPropertyObject: ComputedPropertyObject;
   isLoading = true;
-  dateTimeFormat = 'yyyy-MM-ddThh:mm:ssZZZZZ';
+  dateTimeFormat = 'yyyy-MM-ddTHH:mm:ssZZZZZ';
 
   constructor(
     protected inventoryService: InventoryService,

--- a/asset-properties-widget/component/asset-properties-view/asset-properties-view.service.ts
+++ b/asset-properties-widget/component/asset-properties-view/asset-properties-view.service.ts
@@ -79,7 +79,7 @@ export class AssetPropertiesViewService {
 
   async getLastDeviceMessage(device: IManagedObject) {
     // By incrementing the dateTo parameter by 1 day, this code aims to mitigate timezone-related inconsistencies.
-    const dateTimeFormat = 'yyyy-MM-ddThh:mm:ssZZZZZ';
+    const dateTimeFormat = 'yyyy-MM-ddTHH:mm:ssZZZZZ';
     const filters = {
       dateFrom: this.DEFAULT_FROM_DATE,
       dateTo: this.datePipe.transform(new Date().setDate(new Date().getDate() + 1), dateTimeFormat),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumulocity-asset-properties-widget-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Asset properties",
   "author": "Amarjyoti Raj - Software AG, IOT-Apps R&D",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR fixes an issue with the time format in the Asset Property Widget. Previously, the widget incorrectly displayed times in a 12-hour format; this has now been corrected to display times in a 24-hour format for consistency.